### PR TITLE
Called computeMetric in processUrls.ts, added utils.ts

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 LOG_LEVEL = 0
 LOG_FILE = '/src/log.txt'
+GITHUB_TOKEN = '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'

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 LOG_LEVEL = 0
 LOG_FILE = '/src/log.txt'
-GITHUB_TOKEN = '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'
+GITHUB_TOKEN = 

--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-LOG_LEVEL = 0
-LOG_FILE = '/src/log.txt'
-GITHUB_TOKEN = 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
+/cloned_repos
 package-lock.json
-*.js
+.env

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "dotenv": "^16.4.5",
     "simple-git": "^3.26.0"
   }
 }

--- a/run
+++ b/run
@@ -2,7 +2,7 @@
 
 # Function to install dependencies (sort of)
 install() {
-    echo "start installing dependencies..."
+    echo -e "start installing dependencies...\\n"
     npm install
     if [ $? -eq 0 ]; then
         echo "Dependencies installed successfully."
@@ -15,7 +15,7 @@ install() {
 
 # Function to run tests (sort of)
 run_tests() {
-    echo "start testing project"
+    echo -e "start testing project...\\n"
     # npx ts-node src/processUrls.ts src/input.txt
     # npm test    
     # if [ $? -eq 0 ]; then
@@ -29,7 +29,7 @@ run_tests() {
 
 # Function to process URLs using TypeScript
 process_urls() {
-    echo "start processing urls..."
+    echo -e "start processing urls...\\n"
     URL_FILE=$1
     if [ -f "$URL_FILE" ]; then
         npx ts-node src/processUrls.ts "$URL_FILE"

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -145,6 +145,7 @@ function metricsRunner(metricFn, packageUrl, packagePath) {
 }
 /**
  * @function countIssue
+ * @description A function that returns #issues in 'state'(ex: closed) from given repo information using GH API
  * @param {string} owner - the owner of the repo, we use this to construct the endpoint for API call
  * @param {string} packageName - package's name, used to construct API as well
  * @param {string} status - the status of the kinf of issue we want to get, like 'closed'
@@ -163,7 +164,7 @@ function countIssue(owner, repo, state) {
                                 Authorization: "token ".concat(GITHUB_TOKEN)
                             },
                             params: {
-                                per_page: 1 // To avoid fetching full data, we'll just look at the "Link" header for pagination
+                                per_page: 1 /* Avoid fetching full data by looking at only the "Link" header for pagination */
                             }
                         })];
                 case 1:
@@ -175,7 +176,7 @@ function countIssue(owner, repo, state) {
                             return [2 /*return*/, parseInt(lastPageMatch[1], 10)];
                         }
                     }
-                    return [2 /*return*/, response.data.length]; // Fallback if there is no pagination
+                    return [2 /*return*/, response.data.length];
                 case 2:
                     error_1 = _a.sent();
                     console.error("Error fetching ".concat(state, " issues for ").concat(owner, "/").concat(repo, ":"), error_1);
@@ -188,7 +189,10 @@ function countIssue(owner, repo, state) {
 /**
  * @function maintainerActiveness
  * @description A metric that uses GH API to get (1- #openIssue/#allIssue) as maintainerActiveness score.
- * @returns {number} score - A number representing the score ([0, 1])
+ * @param {string} packageUrl - The GitHub repository URL.
+ * @param {string} packagePath - (Not used here, but required for type compatibility).
+ * @returns {number} score - The score for maintainerActiveness, calculated as (1- #openIssue/#allIssue),
+ *                           if no issue was found it returns 1.
  */
 function maintainerActiveness(packageUrl, packagePath) {
     return __awaiter(this, void 0, void 0, function () {
@@ -201,6 +205,8 @@ function maintainerActiveness(packageUrl, packagePath) {
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 4, , 5]);
+                    if (GITHUB_TOKEN == '')
+                        throw new Error('No GitHub token specified');
                     return [4 /*yield*/, countIssue(owner, packageName, 'all')];
                 case 2:
                     totalIssues = _b.sent();
@@ -223,11 +229,11 @@ function maintainerActiveness(packageUrl, packagePath) {
 ;
 /**
  * @function busFactor
-* @description A metric that calculates the number of contributors with 5+ commits in the last year.
-* @param {string} packageUrl - The GitHub repository URL.
-* @param {string} packagePath - (Not used here, but required for type compatibility).
-* @returns {Promise<number>} - The score for busFactor, calculated as max(1, (#contributors who made 5+ commits last year / 10))
-*/
+ * @description A metric that calculates the number of contributors with 5+ commits in the last year.
+ * @param {string} packageUrl - The GitHub repository URL.
+ * @param {string} packagePath - (Not used here, but required for type compatibility).
+ * @returns {Promise<number>} - The score for busFactor, calculated as max(1, (#contributors who made 5+ commits last year / 10))
+ */
 function busFactor(packageUrl, packagePath) {
     return __awaiter(this, void 0, void 0, function () {
         var _a, owner, packageName, since, url, response, commits, contributorCommits_1, activeContributors, score, error_3;
@@ -238,6 +244,8 @@ function busFactor(packageUrl, packagePath) {
                     _b.label = 1;
                 case 1:
                     _b.trys.push([1, 3, , 4]);
+                    if (GITHUB_TOKEN == '')
+                        throw new Error('No GitHub token specified');
                     since = new Date();
                     since.setFullYear(since.getFullYear() - 1);
                     url = "https://api.github.com/repos/".concat(owner, "/").concat(packageName, "/commits");

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,0 +1,292 @@
+"use strict";
+/**
+ * computeMetrics is the only externally accessible function from this file. It facilitates running
+ * multiple metrics in parallel. To add a metric calculation, create a function definition that follows the
+ * typing (type metricFunction) and add the function name to the metrics array. Metric functions must be
+ * asynchronous (return promises). metricSample shows how to make a synchoronous function asynchronous.
+ */
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var _a, _b;
+Object.defineProperty(exports, "__esModule", { value: true });
+// import { spawn } from 'child_process';
+// import * as fs from 'fs';
+var threading = require("worker_threads");
+var os_1 = require("os");
+var axios_1 = require("axios");
+var util_1 = require("./util");
+var dotenv = require("dotenv");
+dotenv.config();
+var GITHUB_TOKEN = (_a = process.env.GITHUB_TOKEN) !== null && _a !== void 0 ? _a : '';
+var metrics = [busFactor, maintainerActiveness];
+;
+/**
+ * @function computeMetrics
+ * @description This function is used to compute the metrics of a package.
+ * @returns {packageResult} - A map describing the package, including the scores and latencies of the metrics.
+ */
+function computeMetrics(packageUrl, packagePath) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/, new Promise(function (resolve, reject) {
+                    var cores = (0, os_1.cpus)().length;
+                    var maxWorkers = Math.min(cores, 2 * metrics.length);
+                    var metricThreads = [];
+                    var results = [];
+                    var completed = 0;
+                    var started = 0;
+                    function startNewWorker(metricIndex) {
+                        if (metricIndex >= metrics.length) {
+                            return;
+                        }
+                        var newWorker = new threading.Worker(__filename, {
+                            workerData: {
+                                metricIndex: metricIndex, url: packageUrl, path: packagePath
+                            },
+                        });
+                        var subChannel = new threading.MessageChannel();
+                        newWorker.postMessage({ hereIsYourPort: subChannel.port1 }, [subChannel.port1]);
+                        subChannel.port2.on('message', function (message) {
+                            var _a;
+                            results.push((_a = {},
+                                _a[message.metricName] = message.result[0],
+                                _a["".concat(message.metricName, "_Latency")] = message.result[1],
+                                _a));
+                            completed++;
+                            if (completed === metrics.length) {
+                                var finalResult_1 = __assign({ URL: packageUrl, NetScore: results.reduce(function (acc, curr) { return acc + curr[Object.keys(curr)[0]]; }, 0) / metrics.length, NetScore_Latency: results.reduce(function (acc, curr) { return acc + curr["".concat(Object.keys(curr)[0], "_Latency")]; }, 0) / metrics.length }, results.reduce(function (acc, curr) { return (__assign(__assign({}, acc), curr)); }, {}));
+                                var terminationPromises = metricThreads.map(function (worker) { return worker.terminate(); });
+                                Promise.all(terminationPromises).then(function () {
+                                    resolve(finalResult_1);
+                                }).catch(function (error) { console.log(error); });
+                            }
+                            else {
+                                startNewWorker(started++);
+                            }
+                        });
+                        newWorker.on('error', function (err) {
+                            reject(err);
+                        });
+                        metricThreads.push(newWorker);
+                        started++;
+                    }
+                    for (var i = 0; i < maxWorkers; i++) {
+                        startNewWorker(i);
+                    }
+                })];
+        });
+    });
+}
+/**
+ * @function metricsRunner
+ * @param metricFunction - The function to run to collect a given metric.
+ * @returns {number[]} - A pair of numbers representing the score ([0, 1]) and the latency in seconds.
+ */
+function metricsRunner(metricFn, packageUrl, packagePath) {
+    return __awaiter(this, void 0, void 0, function () {
+        var startTime, score, latency;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    startTime = Date.now();
+                    return [4 /*yield*/, metricFn(packageUrl, packagePath)];
+                case 1:
+                    score = _a.sent();
+                    latency = (Date.now() - startTime) / 1000;
+                    return [2 /*return*/, [score, latency]];
+            }
+        });
+    });
+}
+/**
+ * @function countIssue
+ * @param {string} owner - the owner of the repo, we use this to construct the endpoint for API call
+ * @param {string} packageName - package's name, used to construct API as well
+ * @param {string} status - the status of the kinf of issue we want to get, like 'closed'
+ * @returns {number} count - the number of issue in the status specified
+ */
+function countIssue(owner, repo, state) {
+    return __awaiter(this, void 0, void 0, function () {
+        var url, response, linkHeader, lastPageMatch, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    _a.trys.push([0, 2, , 3]);
+                    url = "https://api.github.com/repos/".concat(owner, "/").concat(repo, "/issues?state=").concat(state);
+                    return [4 /*yield*/, axios_1.default.get(url, {
+                            headers: {
+                                Authorization: "token ".concat(GITHUB_TOKEN)
+                            },
+                            params: {
+                                per_page: 1 // To avoid fetching full data, we'll just look at the "Link" header for pagination
+                            }
+                        })];
+                case 1:
+                    response = _a.sent();
+                    linkHeader = response.headers.link;
+                    if (linkHeader) {
+                        lastPageMatch = linkHeader.match(/&page=(\d+)>; rel="last"/);
+                        if (lastPageMatch) {
+                            return [2 /*return*/, parseInt(lastPageMatch[1], 10)];
+                        }
+                    }
+                    return [2 /*return*/, response.data.length]; // Fallback if there is no pagination
+                case 2:
+                    error_1 = _a.sent();
+                    console.error("Error fetching ".concat(state, " issues for ").concat(owner, "/").concat(repo, ":"), error_1);
+                    return [2 /*return*/, 0];
+                case 3: return [2 /*return*/];
+            }
+        });
+    });
+}
+/**
+ * @function maintainerActiveness
+ * @description A metric that uses GH API to get (1- #openIssue/#allIssue) as maintainerActiveness score.
+ * @returns {number} score - A number representing the score ([0, 1])
+ */
+function maintainerActiveness(packageUrl, packagePath) {
+    return __awaiter(this, void 0, void 0, function () {
+        var score, _a, owner, packageName, totalIssues, openIssues, error_2;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    score = 0;
+                    _a = (0, util_1.getOwnerAndPackageName)(packageUrl), owner = _a[0], packageName = _a[1];
+                    _b.label = 1;
+                case 1:
+                    _b.trys.push([1, 4, , 5]);
+                    return [4 /*yield*/, countIssue(owner, packageName, 'all')];
+                case 2:
+                    totalIssues = _b.sent();
+                    return [4 /*yield*/, countIssue(owner, packageName, 'open')];
+                case 3:
+                    openIssues = _b.sent();
+                    if (totalIssues === 0) {
+                        return [2 /*return*/, 1]; /* No issue at all, the score here can be changed later */
+                    }
+                    score = 1 - (openIssues / totalIssues);
+                    return [3 /*break*/, 5];
+                case 4:
+                    error_2 = _b.sent();
+                    throw new Error("Error calculating maintaine activeness\nError message : ".concat(error_2));
+                case 5: return [2 /*return*/, score];
+            }
+        });
+    });
+}
+;
+/**
+ * @function busFactor
+* @description A metric that calculates the number of contributors with 5+ commits in the last year.
+* @param {string} packageUrl - The GitHub repository URL.
+* @param {string} packagePath - (Not used here, but required for type compatibility).
+* @returns {Promise<number>} - The score for busFactor, calculated as max(1, (#contributors who made 5+ commits last year / 10))
+*/
+function busFactor(packageUrl, packagePath) {
+    return __awaiter(this, void 0, void 0, function () {
+        var _a, owner, packageName, since, url, response, commits, contributorCommits_1, activeContributors, score, error_3;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _a = (0, util_1.getOwnerAndPackageName)(packageUrl), owner = _a[0], packageName = _a[1];
+                    _b.label = 1;
+                case 1:
+                    _b.trys.push([1, 3, , 4]);
+                    since = new Date();
+                    since.setFullYear(since.getFullYear() - 1);
+                    url = "https://api.github.com/repos/".concat(owner, "/").concat(packageName, "/commits");
+                    return [4 /*yield*/, axios_1.default.get(url, {
+                            params: {
+                                since: since.toISOString(),
+                                per_page: 100, /* This is just a rough guess */
+                            },
+                            headers: {
+                                Authorization: "token ".concat(GITHUB_TOKEN)
+                            }
+                        })];
+                case 2:
+                    response = _b.sent();
+                    commits = response.data;
+                    if (!commits || commits.length === 0)
+                        return [2 /*return*/, 0]; /* No contributors found in the last year */
+                    contributorCommits_1 = {};
+                    /* Count commits per author */
+                    commits.forEach(function (commit) {
+                        var _a;
+                        var author = (_a = commit.author) === null || _a === void 0 ? void 0 : _a.login;
+                        if (author) {
+                            contributorCommits_1[author] = (contributorCommits_1[author] || 0) + 1;
+                        }
+                    });
+                    activeContributors = Object.values(contributorCommits_1).filter(function (commitCount) { return commitCount >= 5; }).length;
+                    score = activeContributors >= 10 ? 1 : activeContributors / 10;
+                    return [2 /*return*/, score];
+                case 3:
+                    error_3 = _b.sent();
+                    console.error("Error calculating activeContributorsMetric: ".concat(error_3));
+                    return [2 /*return*/, 0];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+}
+if (!threading.isMainThread) {
+    var _c = threading.workerData, metricIndex = _c.metricIndex, url_1 = _c.url, path_1 = _c.path;
+    var metric_1 = metrics[metricIndex];
+    (_b = threading.parentPort) === null || _b === void 0 ? void 0 : _b.once('message', function (childPort) {
+        metricsRunner(metric_1, url_1, path_1).then(function (metricResult) {
+            childPort.hereIsYourPort.postMessage({ metricName: metric_1.name, result: metricResult });
+            childPort.hereIsYourPort.close();
+        }).catch(function (error) {
+            console.error(error);
+            childPort.hereIsYourPort.close();
+        });
+    });
+}
+exports.default = computeMetrics;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -170,6 +170,7 @@ async function maintainerActiveness(packageUrl: string, packagePath: string): Pr
     let score = 0;
     const[owner, packageName] = getOwnerAndPackageName(packageUrl);
     try {
+        if (GITHUB_TOKEN == '') throw new Error('No GitHub token specified');
         const totalIssues = await countIssue(owner, packageName, 'all');
         const openIssues = await countIssue(owner, packageName, 'open');
 
@@ -195,6 +196,7 @@ async function maintainerActiveness(packageUrl: string, packagePath: string): Pr
 async function busFactor(packageUrl: string, packagePath: string): Promise<number> {
     const[owner, packageName] = getOwnerAndPackageName(packageUrl);
     try {
+        if (GITHUB_TOKEN == '') throw new Error('No GitHub token specified');
         /* Trace back at most a year from today */
         const since = new Date();
         since.setFullYear(since.getFullYear() - 1);

--- a/src/processUrls.js
+++ b/src/processUrls.js
@@ -183,19 +183,23 @@ function cloneRepo(githubUrl, targetDir) {
             switch (_a.label) {
                 case 0:
                     git = (0, simple_git_1.default)();
-                    (0, util_1.handleOutput)("Cloning GitHub repo: ".concat(githubUrl), '');
-                    _a.label = 1;
+                    return [4 /*yield*/, (0, util_1.handleOutput)("Cloning GitHub repo: ".concat(githubUrl), '')];
                 case 1:
-                    _a.trys.push([1, 3, , 4]);
-                    return [4 /*yield*/, git.clone(githubUrl, targetDir)];
-                case 2:
                     _a.sent();
-                    (0, util_1.handleOutput)("Cloned ".concat(githubUrl, " successfully.\n"), '');
-                    return [3 /*break*/, 4];
+                    _a.label = 2;
+                case 2:
+                    _a.trys.push([2, 5, , 6]);
+                    return [4 /*yield*/, git.clone(githubUrl, targetDir)];
                 case 3:
+                    _a.sent();
+                    return [4 /*yield*/, (0, util_1.handleOutput)("Cloned ".concat(githubUrl, " successfully.\n"), '')];
+                case 4:
+                    _a.sent();
+                    return [3 /*break*/, 6];
+                case 5:
                     error_3 = _a.sent();
                     throw new Error("Failed to clone ".concat(githubUrl, "\nError message : ").concat(error_3));
-                case 4: return [2 /*return*/];
+                case 6: return [2 /*return*/];
             }
         });
     });
@@ -209,10 +213,11 @@ function cloneRepo(githubUrl, targetDir) {
 function processURLs(filePath) {
     return __awaiter(this, void 0, void 0, function () {
         var urls, i, _i, urls_1, url, githubUrl, pathSegments, owner, packageName, error_4, error_5;
+        var _this = this;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    _a.trys.push([0, 12, , 13]);
+                    _a.trys.push([0, 15, , 18]);
                     return [4 /*yield*/, readURLFile(filePath)];
                 case 1:
                     urls = _a.sent();
@@ -220,52 +225,88 @@ function processURLs(filePath) {
                     _i = 0, urls_1 = urls;
                     _a.label = 2;
                 case 2:
-                    if (!(_i < urls_1.length)) return [3 /*break*/, 11];
+                    if (!(_i < urls_1.length)) return [3 /*break*/, 14];
                     url = urls_1[_i];
-                    (0, util_1.handleOutput)("Processing URLs (".concat(i++, "/").concat(urls.length, ") --> ").concat(url), '');
-                    return [4 /*yield*/, classifyAndConvertURL(url)];
+                    return [4 /*yield*/, (0, util_1.handleOutput)("Processing URLs (".concat((i++).toString(), "/").concat((urls.length).toString(), ") --> ").concat(url), '')];
                 case 3:
+                    _a.sent();
+                    return [4 /*yield*/, classifyAndConvertURL(url)];
+                case 4:
                     githubUrl = _a.sent();
-                    if (!githubUrl) return [3 /*break*/, 9];
+                    if (!githubUrl) return [3 /*break*/, 12];
                     pathSegments = githubUrl.pathname.split('/').filter(Boolean);
                     if (pathSegments.length != 2)
                         throw new Error("Not a repo url : ".concat(pathSegments.toString()));
                     owner = pathSegments[0];
                     packageName = pathSegments[1].replace('.git', '');
-                    _a.label = 4;
-                case 4:
-                    _a.trys.push([4, 7, , 8]);
-                    return [4 /*yield*/, cloneRepo(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))];
+                    _a.label = 5;
                 case 5:
-                    _a.sent();
-                    return [4 /*yield*/, (0, metrics_1.default)(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))
-                            .then(function (result) {
-                            (0, util_1.handleOutput)("Metrics Results : \n".concat(result), '');
-                        })
-                            .catch(function (error) {
-                            (0, util_1.handleOutput)('', "Error computing metrics\nError message : ".concat(error));
-                        })];
+                    _a.trys.push([5, 8, , 10]);
+                    return [4 /*yield*/, cloneRepo(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))];
                 case 6:
                     _a.sent();
-                    return [3 /*break*/, 8];
+                    return [4 /*yield*/, (0, metrics_1.default)(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))
+                            .then(function (result) { return __awaiter(_this, void 0, void 0, function () {
+                            var resultObj, formatResult, key;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0:
+                                        resultObj = result;
+                                        formatResult = 'Metrics Results :\n';
+                                        for (key in resultObj) {
+                                            if (typeof resultObj[key] === 'number' && resultObj[key] % 1 !== 0) {
+                                                /* Truncate floating number after 3 decimal points  */
+                                                formatResult += " + ".concat(key, " : ").concat(resultObj[key].toFixed(3), "\n");
+                                            }
+                                            else {
+                                                formatResult += " + ".concat(key, " : ").concat(resultObj[key], "\n");
+                                            }
+                                        }
+                                        return [4 /*yield*/, (0, util_1.handleOutput)(formatResult, '')];
+                                    case 1:
+                                        _a.sent();
+                                        return [2 /*return*/];
+                                }
+                            });
+                        }); })
+                            .catch(function (error) { return __awaiter(_this, void 0, void 0, function () {
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0: return [4 /*yield*/, (0, util_1.handleOutput)('', "Error computing metrics\nError message : ".concat(error))];
+                                    case 1:
+                                        _a.sent();
+                                        return [2 /*return*/];
+                                }
+                            });
+                        }); })];
                 case 7:
-                    error_4 = _a.sent();
-                    (0, util_1.handleOutput)('', "Error handling url ".concat(githubUrl, "\nError message : ").concat(error_4));
-                    return [3 /*break*/, 8];
-                case 8:
-                    (0, util_1.handleOutput)('-'.repeat(50), '');
+                    _a.sent();
                     return [3 /*break*/, 10];
-                case 9: throw new Error('GitHub URL is null.');
-                case 10:
+                case 8:
+                    error_4 = _a.sent();
+                    return [4 /*yield*/, (0, util_1.handleOutput)('', "Error handling url ".concat(githubUrl, "\nError message : ").concat(error_4))];
+                case 9:
+                    _a.sent();
+                    return [3 /*break*/, 10];
+                case 10: return [4 /*yield*/, (0, util_1.handleOutput)('-'.repeat(80), '')];
+                case 11:
+                    _a.sent();
+                    return [3 /*break*/, 13];
+                case 12: throw new Error('GitHub URL is null.');
+                case 13:
                     _i++;
                     return [3 /*break*/, 2];
-                case 11: return [3 /*break*/, 13];
-                case 12:
+                case 14: return [3 /*break*/, 18];
+                case 15:
                     error_5 = _a.sent();
-                    (0, util_1.handleOutput)('', "Error processing the URL file\nError message : ".concat(error_5));
-                    (0, util_1.handleOutput)('-'.repeat(50), '');
-                    return [3 /*break*/, 13];
-                case 13: return [2 /*return*/];
+                    return [4 /*yield*/, (0, util_1.handleOutput)('', "Error processing the URL file\nError message : ".concat(error_5))];
+                case 16:
+                    _a.sent();
+                    return [4 /*yield*/, (0, util_1.handleOutput)('-'.repeat(50), '')];
+                case 17:
+                    _a.sent();
+                    return [3 /*break*/, 18];
+                case 18: return [2 /*return*/];
             }
         });
     });

--- a/src/processUrls.js
+++ b/src/processUrls.js
@@ -49,6 +49,8 @@ var readline = require("readline");
 var simple_git_1 = require("simple-git");
 var axios_1 = require("axios");
 var url_1 = require("url");
+var util_1 = require("./util");
+var metrics_1 = require("./metrics");
 /**
  * @function readURLFile
  * @description Reads a file line by line and extracts the URLs.
@@ -129,7 +131,7 @@ function classifyAndConvertURL(urlString) {
                     if (!(parsedUrl.hostname === 'www.npmjs.com')) return [3 /*break*/, 6];
                     packageName = parsedUrl.pathname.split('/').pop();
                     if (!packageName) {
-                        handleOutput('', "Invalid npm URL: ".concat(urlString));
+                        (0, util_1.handleOutput)('', "Invalid npm URL: ".concat(urlString));
                         return [2 /*return*/, null];
                     }
                     _b.label = 2;
@@ -142,25 +144,25 @@ function classifyAndConvertURL(urlString) {
                     if (repoUrl && repoUrl.includes('github.com')) {
                         githubUrl = new url_1.URL(repoUrl.replace(/^git\+/, '').replace(/\.git$/, '').replace('ssh://git@github.com/', 'https://github.com/'));
                         githubUrl.pathname += '.git';
-                        handleOutput("npm converted to GitHub URL: ".concat(githubUrl.toString()), '');
+                        (0, util_1.handleOutput)("npm converted to GitHub URL: ".concat(githubUrl.toString()), '');
                         return [2 /*return*/, githubUrl];
                     }
                     else {
-                        handleOutput('', "No GitHub repository found for npm package: ".concat(packageName));
+                        (0, util_1.handleOutput)('', "No GitHub repository found for npm package: ".concat(packageName));
                     }
                     return [3 /*break*/, 5];
                 case 4:
                     error_1 = _b.sent();
-                    handleOutput('', "Failed to retrieve npm package data: ".concat(packageName, "\nError message: ").concat(error_1));
+                    (0, util_1.handleOutput)('', "Failed to retrieve npm package data: ".concat(packageName, "\nError message: ").concat(error_1));
                     return [3 /*break*/, 5];
                 case 5: return [3 /*break*/, 7];
                 case 6:
-                    handleOutput('', "Unknown URL type: ".concat(urlString, ", neither GitHub nor npm"));
+                    (0, util_1.handleOutput)('', "Unknown URL type: ".concat(urlString, ", neither GitHub nor npm"));
                     _b.label = 7;
                 case 7: return [3 /*break*/, 9];
                 case 8:
                     error_2 = _b.sent();
-                    handleOutput('', "Failed to parse the URL: ".concat(urlString, "\nError message : ").concat(error_2));
+                    (0, util_1.handleOutput)('', "Failed to parse the URL: ".concat(urlString, "\nError message : ").concat(error_2));
                     return [3 /*break*/, 9];
                 case 9: return [2 /*return*/, null];
             }
@@ -181,18 +183,18 @@ function cloneRepo(githubUrl, targetDir) {
             switch (_a.label) {
                 case 0:
                     git = (0, simple_git_1.default)();
+                    (0, util_1.handleOutput)("Cloning GitHub repo: ".concat(githubUrl), '');
                     _a.label = 1;
                 case 1:
                     _a.trys.push([1, 3, , 4]);
                     return [4 /*yield*/, git.clone(githubUrl, targetDir)];
                 case 2:
                     _a.sent();
-                    handleOutput("Cloned ".concat(githubUrl, " successfully.\n"), '');
+                    (0, util_1.handleOutput)("Cloned ".concat(githubUrl, " successfully.\n"), '');
                     return [3 /*break*/, 4];
                 case 3:
                     error_3 = _a.sent();
-                    handleOutput('', "Failed to clone ".concat(githubUrl, "\nError message : ").concat(error_3));
-                    return [3 /*break*/, 4];
+                    throw new Error("Failed to clone ".concat(githubUrl, "\nError message : ").concat(error_3));
                 case 4: return [2 /*return*/];
             }
         });
@@ -206,11 +208,11 @@ function cloneRepo(githubUrl, targetDir) {
 */
 function processURLs(filePath) {
     return __awaiter(this, void 0, void 0, function () {
-        var urls, i, _i, urls_1, url, githubUrl, pathSegments, owner, packageName, error_4;
+        var urls, i, _i, urls_1, url, githubUrl, pathSegments, owner, packageName, error_4, error_5;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    _a.trys.push([0, 8, , 9]);
+                    _a.trys.push([0, 12, , 13]);
                     return [4 /*yield*/, readURLFile(filePath)];
                 case 1:
                     urls = _a.sent();
@@ -218,70 +220,53 @@ function processURLs(filePath) {
                     _i = 0, urls_1 = urls;
                     _a.label = 2;
                 case 2:
-                    if (!(_i < urls_1.length)) return [3 /*break*/, 7];
+                    if (!(_i < urls_1.length)) return [3 /*break*/, 11];
                     url = urls_1[_i];
-                    handleOutput("Processing URLs (".concat(i++, "/").concat(urls.length, ") --> ").concat(url), '');
+                    (0, util_1.handleOutput)("Processing URLs (".concat(i++, "/").concat(urls.length, ") --> ").concat(url), '');
                     return [4 /*yield*/, classifyAndConvertURL(url)];
                 case 3:
                     githubUrl = _a.sent();
-                    if (!githubUrl) return [3 /*break*/, 5];
+                    if (!githubUrl) return [3 /*break*/, 9];
                     pathSegments = githubUrl.pathname.split('/').filter(Boolean);
                     if (pathSegments.length != 2)
-                        throw new Error('Not a repo url');
+                        throw new Error("Not a repo url : ".concat(pathSegments.toString()));
                     owner = pathSegments[0];
                     packageName = pathSegments[1].replace('.git', '');
-                    handleOutput("Cloning GitHub repo: ".concat(githubUrl), '');
-                    return [4 /*yield*/, cloneRepo(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))];
+                    _a.label = 4;
                 case 4:
+                    _a.trys.push([4, 7, , 8]);
+                    return [4 /*yield*/, cloneRepo(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))];
+                case 5:
                     _a.sent();
-                    return [3 /*break*/, 6];
-                case 5: throw new Error('GitHub URL is null.');
+                    return [4 /*yield*/, (0, metrics_1.default)(githubUrl.toString(), "./cloned_repos/".concat(owner, " ").concat(packageName))
+                            .then(function (result) {
+                            (0, util_1.handleOutput)("Metrics Results : \n".concat(result), '');
+                        })
+                            .catch(function (error) {
+                            (0, util_1.handleOutput)('', "Error computing metrics\nError message : ".concat(error));
+                        })];
                 case 6:
+                    _a.sent();
+                    return [3 /*break*/, 8];
+                case 7:
+                    error_4 = _a.sent();
+                    (0, util_1.handleOutput)('', "Error handling url ".concat(githubUrl, "\nError message : ").concat(error_4));
+                    return [3 /*break*/, 8];
+                case 8:
+                    (0, util_1.handleOutput)('-'.repeat(50), '');
+                    return [3 /*break*/, 10];
+                case 9: throw new Error('GitHub URL is null.');
+                case 10:
                     _i++;
                     return [3 /*break*/, 2];
-                case 7: return [3 /*break*/, 9];
-                case 8:
-                    error_4 = _a.sent();
-                    handleOutput('', "Error processing the URL file\nError message : ".concat(error_4));
-                    return [3 /*break*/, 9];
-                case 9: return [2 /*return*/];
+                case 11: return [3 /*break*/, 13];
+                case 12:
+                    error_5 = _a.sent();
+                    (0, util_1.handleOutput)('', "Error processing the URL file\nError message : ".concat(error_5));
+                    (0, util_1.handleOutput)('-'.repeat(50), '');
+                    return [3 /*break*/, 13];
+                case 13: return [2 /*return*/];
             }
-        });
-    });
-}
-/**
- * @function handleOutput
- * @description Handles the output of the result, error message, or log file. At least one of the message/errorMessage must be specified.
- * @param {string} message - Optional message to log.
- * @param {string} errorMessage - Optional error message to log.
- * @param {number} endpoint - Display endpoint for output (0: console, 1: log file).
- */
-function handleOutput() {
-    return __awaiter(this, arguments, void 0, function (message, errorMessage, endpoint) {
-        if (message === void 0) { message = ''; }
-        if (errorMessage === void 0) { errorMessage = ''; }
-        if (endpoint === void 0) { endpoint = 0; }
-        return __generator(this, function (_a) {
-            switch (endpoint) {
-                case 0: {
-                    if (message != '')
-                        console.log(message);
-                    if (errorMessage != '')
-                        console.error(errorMessage);
-                    break;
-                }
-                case 1: {
-                    break;
-                }
-                default: {
-                    if (message != '')
-                        console.log(message);
-                    if (errorMessage != '')
-                        console.error(new Error(errorMessage));
-                    break;
-                }
-            }
-            return [2 /*return*/];
         });
     });
 }
@@ -289,7 +274,7 @@ function handleOutput() {
 if (require.main === module) {
     var filePath = process.argv[2];
     if (!filePath) {
-        handleOutput('', 'No file path given. Please provide a URL file path as an argument.');
+        (0, util_1.handleOutput)('', 'No file path given. Please provide a URL file path as an argument.');
         process.exit(1);
     }
     processURLs(filePath);

--- a/src/test_expected_output.txt
+++ b/src/test_expected_output.txt
@@ -1,37 +1,100 @@
-./run /src/test_input.txt
 start processing urls...
+
 Processing URLs (1/8) --> https://github.com/cloudinary/cloudinary_npm
 Cloning GitHub repo: https://github.com/cloudinary/cloudinary_npm
 Cloned https://github.com/cloudinary/cloudinary_npm successfully.
 
+Metrics Results :
+ + URL : https://github.com/cloudinary/cloudinary_npm
+ + NetScore : 0.535
+ + NetScore_Latency : 0.471
+ + busFactor : 0.100
+ + busFactor_Latency : 0.451
+ + maintainerActiveness : 0.971
+ + maintainerActiveness_Latency : 0.491
+
+--------------------------------------------------------------------------------
 Processing URLs (2/8) --> https://www.npmjs.com/package/express
 npm converted to GitHub URL: https://github.com/expressjs/express.git
 Cloning GitHub repo: https://github.com/expressjs/express.git
 Cloned https://github.com/expressjs/express.git successfully.
 
+Metrics Results :
+ + URL : https://github.com/expressjs/express.git
+ + NetScore : 0.784
+ + NetScore_Latency : 0.374
+ + maintainerActiveness : 0.969
+ + maintainerActiveness_Latency : 0.369
+ + busFactor : 0.600
+ + busFactor_Latency : 0.379
+
+--------------------------------------------------------------------------------
 Processing URLs (3/8) --> https://github.com/nullivex/nodist
 Cloning GitHub repo: https://github.com/nullivex/nodist
 Cloned https://github.com/nullivex/nodist successfully.
 
+Metrics Results :
+ + URL : https://github.com/nullivex/nodist
+ + NetScore : 0.497
+ + NetScore_Latency : 0.538
+ + busFactor : 0.100
+ + busFactor_Latency : 0.388
+ + maintainerActiveness : 0.893
+ + maintainerActiveness_Latency : 0.688
+
+--------------------------------------------------------------------------------
 Processing URLs (4/8) --> httpsasdfasdf://github.com/midas1214/hw1_github_tutorial.git
 Cloning GitHub repo: httpsasdfasdf://github.com/midas1214/hw1_github_tutorial.git
-Failed to clone httpsasdfasdf://github.com/midas1214/hw1_github_tutorial.git
+Error handling url httpsasdfasdf://github.com/midas1214/hw1_github_tutorial.git
+Error message : Error: Failed to clone httpsasdfasdf://github.com/midas1214/hw1_github_tutorial.git
 Error message : Error: Cloning into './cloned_repos/midas1214 hw1_github_tutorial'...
 git: 'remote-httpsasdfasdf' is not a git command. See 'git --help'.
 
+--------------------------------------------------------------------------------
 Processing URLs (5/8) --> https://github.com/lodash/lodash
 Cloning GitHub repo: https://github.com/lodash/lodash
 Cloned https://github.com/lodash/lodash successfully.
 
+Metrics Results :
+ + URL : https://github.com/lodash/lodash
+ + NetScore : 0.541
+ + NetScore_Latency : 0.297
+ + busFactor : 0.100
+ + busFactor_Latency : 0.248
+ + maintainerActiveness : 0.982
+ + maintainerActiveness_Latency : 0.347
+
+--------------------------------------------------------------------------------
 Processing URLs (6/8) --> https://www.npmjs.com/package/browserify
 npm converted to GitHub URL: https://github.com/browserify/browserify.git
 Cloning GitHub repo: https://github.com/browserify/browserify.git
 Cloned https://github.com/browserify/browserify.git successfully.
 
+Metrics Results :
+ + URL : https://github.com/browserify/browserify.git
+ + NetScore : 0.404
+ + NetScore_Latency : 0.300
+ + busFactor : 0
+ + busFactor_Latency : 0.218
+ + maintainerActiveness : 0.808
+ + maintainerActiveness_Latency : 0.382
+
+--------------------------------------------------------------------------------
 Processing URLs (7/8) --> https://github.com/midas1214/hw1_github_tutorial.git
 Cloning GitHub repo: https://github.com/midas1214/hw1_github_tutorial.git
 Cloned https://github.com/midas1214/hw1_github_tutorial.git successfully.
 
+Metrics Results :
+ + URL : https://github.com/midas1214/hw1_github_tutorial.git
+ + NetScore : 0.550
+ + NetScore_Latency : 0.224
+ + busFactor : 0.100
+ + busFactor_Latency : 0.207
+ + maintainerActiveness : 1
+ + maintainerActiveness_Latency : 0.241
+
+--------------------------------------------------------------------------------
 Processing URLs (8/8) --> https://github.com/ECE46100/group21-phase1/issues
 Error processing the URL file
-Error message : Error: Not a repo url
+Error message : Error: Not a repo url : ECE46100,group21-phase1,issues
+--------------------------------------------------

--- a/src/test_metrics.js
+++ b/src/test_metrics.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var metrics_1 = require("./metrics");
+console.log('Running test_metrics.ts');
+(0, metrics_1.default)('https://www.example.com', '/path/to/package').then(function (result) {
+    console.log('Metrics computed:');
+    console.log(result);
+}).catch(function (error) {
+    console.error('Error computing metrics:');
+    console.error(error);
+});

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,88 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleOutput = handleOutput;
+exports.getOwnerAndPackageName = getOwnerAndPackageName;
+/**
+ * @function handleOutput
+ * @description Handles the output of the result, error message, or log file. At least one of the message/errorMessage must be specified.
+ * @param {string} message - Optional message to log.
+ * @param {string} errorMessage - Optional error message to log.
+ * @param {number} endpoint - Display endpoint for output (0: console, 1: log file).
+ */
+function handleOutput() {
+    return __awaiter(this, arguments, void 0, function (message, errorMessage, endpoint) {
+        if (message === void 0) { message = ''; }
+        if (errorMessage === void 0) { errorMessage = ''; }
+        if (endpoint === void 0) { endpoint = 0; }
+        return __generator(this, function (_a) {
+            switch (endpoint) {
+                case 0: {
+                    if (message != '')
+                        console.log(message);
+                    if (errorMessage != '')
+                        console.error(errorMessage);
+                    break;
+                }
+                case 1: {
+                    break;
+                }
+                default: {
+                    if (message != '')
+                        console.log(message);
+                    if (errorMessage != '')
+                        console.error(new Error(errorMessage));
+                    break;
+                }
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+/**
+ * @function getOwnerAndPackageName
+ * @description A function that extracts owner and packageName from a valid github repo url
+ * @param {string} packageUrl - The GitHub repository url(string).
+ * @returns {[string, string]} - [Owner, packageName]
+ */
+function getOwnerAndPackageName(packageUrl) {
+    var pathSegments = packageUrl.split('/').filter(Boolean);
+    var owner = pathSegments[pathSegments.length - 2];
+    var packageName = pathSegments[pathSegments.length - 1].replace('.git', '');
+    return [owner, packageName];
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,37 @@
+/**
+ * @function handleOutput
+ * @description Handles the output of the result, error message, or log file. At least one of the message/errorMessage must be specified.
+ * @param {string} message - Optional message to log.
+ * @param {string} errorMessage - Optional error message to log.
+ * @param {number} endpoint - Display endpoint for output (0: console, 1: log file).
+ */
+export async function handleOutput(message = '', errorMessage = '', endpoint = 0): Promise<void> {
+    switch(endpoint) { 
+        case 0: { 
+            if (message != '') console.log(message);
+            if (errorMessage != '') console.error(errorMessage);
+            break; 
+        } 
+        case 1: { 
+            break;   
+        } 
+        default: { 
+            if (message != '') console.log(message);
+            if (errorMessage != '') console.error(new Error(errorMessage));
+            break; 
+        } 
+     } 
+}
+
+/**
+ * @function getOwnerAndPackageName
+ * @description A function that extracts owner and packageName from a valid github repo url
+ * @param {string} packageUrl - The GitHub repository url(string).
+ * @returns {[string, string]} - [Owner, packageName]
+ */
+export function getOwnerAndPackageName(packageUrl: string): [string, string]{
+    const pathSegments = packageUrl.split('/').filter(Boolean);
+    const owner = pathSegments[pathSegments.length-2];
+    const packageName = pathSegments[pathSegments.length-1].replace('.git', '');
+    return [owner, packageName];
+}


### PR DESCRIPTION
In this version of the code:
1. The processUrls.ts now runs computeMetrics after cloning the repo successfully.
2. The order of the parameters `packageUrl` and `packagePath` in metricsRunner and computeMetrics were edited.
3. The file utils.ts was added and handleOutput is now moved to the file for easier exporting. A function that extracts owner and packageName from a repo url is also added there.
4. Any changes of metrics.ts needs to be compiled with tsc before they can take effect.
5. The output in terminal was formated using some '-' and '\n' for easier debugging.
6. .env was added to .gitignore